### PR TITLE
Add the first set of guidance for using trademark guidance

### DIFF
--- a/Trademark_policy/trademark-guidance.md
+++ b/Trademark_policy/trademark-guidance.md
@@ -1,0 +1,32 @@
+# GSF Trademark Guidelines
+## Scope
+
+These guidelines cover the ways individuals and companies should talk about the Green Software Foundation and use its mark, either when joining, as an ongoing member, or as a member of the public. Note that the official trademark (coming soon) may be used by non-members provided the wordmarks and logos are used in text truthfully to link to Green Software Foundation content.
+Overview
+
+The Green Software Foundation exists to push for the reduction of carbon emissions that result from software.
+
+These emissions might be from the generation of electricity used to power data centres and user devices or from the manufacturing of the hardware our software runs on.
+
+The Green Software Foundation aims to do this by uncovering, sharing, and promoting best practices for developing and operating green, climate-friendly applications and services.
+
+We want to make it easy to use the trademark, and be confident you’re using as it’s intended to be used.
+
+## Do’s & Don’ts
+
+When using the trademark or talking about your membership of The Green Software Foundation, there are a few do’s and don’ts:
+
+## Do’s:
+
+ - Do use your membership to highlight that you care about green software and are working towards it.
+ - Do use a clearly visible notice to provide attribution, such as: “The Green Software Foundation Mark is a trademark of The Linux Foundation in the US and other countries.”
+ - Do follow the requirements in the Branding Guide when using The Green Software Foundation Mark.
+ - Do point to third party assessed numbers when you talk about your own efforts if at all possible. Are they independently verified? Provide references. Linking to stuff is the point of the web!
+ - Do talk about The Green Software Foundation and all the stuff we’re working on. Everything we do is out in the open, so feel free to share it. That’s our purpose.
+
+## Don’t’s:
+- Don’t imply your membership of The Green Software Foundation means that you’re done. It’s an indication that you’ve joined the race against climate disaster, not crossed the finish line.
+- Don’t imply that The Green Software Foundation has certified you or awarded you anything or endorsed you as a result of being a member. We’re very pleased to have you on board, but it’s just the start.
+
+Have fun with your communications about us! If in doubt whether something’s OK, as long as it meets these do’s and don’ts it’s probably fine. If you’re worried just ask! 
+


### PR DESCRIPTION
This PR introduces the first pass at adding some guidance on using the GSF trademark.

@seanmcilroy29  - I've rebased dev to be level with `main` so this makes for a cleaner PR, but I'd like to discuss a good way to refer to separate guidance pages like this, as I'm not sure what ought to be 'in' the policy, and what we might refer to as external to a single policy